### PR TITLE
:sparkles: Save email after redirect result

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-wagmi",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "wagmi connector to connect with Magic SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/connectors/dedicatedWalletConnector.ts
+++ b/src/lib/connectors/dedicatedWalletConnector.ts
@@ -44,6 +44,7 @@ export abstract class DedicatedWalletConnector extends MagicConnector {
   >
   oauthCallbackUrl?: string
   magicOptions: MagicOptions
+  email?: string
 
   constructor(config: { chains?: Chain[]; options: DedicatedWalletOptions }) {
     super(config)
@@ -80,7 +81,12 @@ export abstract class DedicatedWalletConnector extends MagicConnector {
       if (isLoggedIn) return true
 
       const result = await magic.oauth.getRedirectResult()
-      return result !== null
+      if (result !== null) {
+        this.email = result.magic.userMetadata.email ?? ''
+        return true
+    }
+
+    return false
     } catch {}
     return false
   }

--- a/src/lib/connectors/magicWalletConnector.ts
+++ b/src/lib/connectors/magicWalletConnector.ts
@@ -30,7 +30,6 @@ type ConnectionType = typeof connection[Keys]
  * @see https://magic.link/docs/dedicated/overview
  */
 export class MagicWalletConnector extends DedicatedWalletConnector {
-  email: string
   connectionType: ConnectionType
 
   constructor(config: {
@@ -107,7 +106,7 @@ export class MagicWalletConnector extends DedicatedWalletConnector {
     const magic = this.getMagicSDK()
 
     // LOGIN WITH MAGIC USING EMAIL
-    if (this.connectionType === connection.email)
+    if (this.connectionType === connection.email && this.email)
       await magic.auth.loginWithEmailOTP({
         email: this.email,
       })


### PR DESCRIPTION
This is the only way to have the email after the auto-connect in the application. For some strange reason, if I try to get the user information in the application (`getInfo` or `getMetadata`) after authentication, the email is null.