### PR TITLE
:bug: Use email from oauth response instead of user metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-wagmi",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "wagmi connector to connect with Magic SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/connectors/dedicatedWalletConnector.ts
+++ b/src/lib/connectors/dedicatedWalletConnector.ts
@@ -82,7 +82,7 @@ export abstract class DedicatedWalletConnector extends MagicConnector {
 
       const result = await magic.oauth.getRedirectResult()
       if (result !== null) {
-        this.email = result.magic.userMetadata.email ?? ''
+        this.email = result.oauth.userInfo.email ?? ''
         return true
     }
 


### PR DESCRIPTION
![Screenshot from 2024-04-14 16-20-27](https://github.com/arch-protocol/wagmi-magic-connector/assets/2762088/6818f6a5-a9bd-4990-9fd5-16443eeee308)
